### PR TITLE
Changes for new Twitter API

### DIFF
--- a/chirpy/api.py
+++ b/chirpy/api.py
@@ -146,7 +146,7 @@ class TwitterCall(object):
             uriparts.append(str(kwargs.pop(uripart, uripart)))
         uri = '/'.join(uriparts)
 
-        json_body = kwargs.pop('json', None)
+        json_body = kwargs.pop('_json', None)
 
         method = kwargs.pop('_method', None)
         if not method:

--- a/chirpy/api.py
+++ b/chirpy/api.py
@@ -188,7 +188,7 @@ class TwitterCall(object):
         headers.update(self.headers)
 
         if json_body is not None:
-            headers['Content-Type'] = 'application/json'
+            headers['Content-Type'] = 'application/json; charset=utf-8'
 
         if method == 'GET' or method == 'DELETE':
             request = partial(requests.request, params=kwargs)

--- a/chirpy/api.py
+++ b/chirpy/api.py
@@ -188,7 +188,7 @@ class TwitterCall(object):
         headers.update(self.headers)
 
         if json_body is not None:
-            headers['content-type'] = 'application/json'
+            headers['Content-Type'] = 'application/json'
 
         if method == 'GET' or method == 'DELETE':
             request = partial(requests.request, params=kwargs)

--- a/chirpy/api.py
+++ b/chirpy/api.py
@@ -146,9 +146,15 @@ class TwitterCall(object):
             uriparts.append(str(kwargs.pop(uripart, uripart)))
         uri = '/'.join(uriparts)
 
+        json_body = kwargs.pop('json', None)
+
         method = kwargs.pop('_method', None)
         if not method:
             method = "GET"
+
+            if json_body is not None:
+                method = "POST"
+
             for action in POST_ACTIONS:
                 if re.search("%s(/\d+)?$" % action, uri):
                     method = "POST"
@@ -181,7 +187,6 @@ class TwitterCall(object):
         headers = {'Accept-Encoding': 'gzip'}
         headers.update(self.headers)
 
-        json_body = kwargs.pop('json', None)
         if json_body is not None:
             headers['content-type'] = 'application/json'
 


### PR DESCRIPTION
These are changes I made for the new Twitter API. Specifically, I needed to accommodate the following two scenarios:

- I needed to be able to attach a JSON body to the request, since new Twitter endpoints do not allow form requests
- I needed to be able to support `DELETE` requests

I made 3 changes to accommodate these:

- I added the `or method == 'DELETE'` clause to treat `DELETE` methods similar to `GET` methods. (This is backwards compatible since we never used the `DELETE` method before.)
- I added support for a `json` keyword argument that will set the `content-type` header to `application/json`, and set the request body to the stringified JSON. (This is also backwards compatible since it's opt-in by adding a `json` argument.)
- I made it so that responses with the status code 204 do not attempt to parse the body of the request. (This should be backwards compatible, since 204 literally means "No Content".)

If I added you as an assignee it's because I though you might have some insight into this repo and upgrading it. If you don't, feel free to ignore this. 😄 