### PR TITLE
Support PUT requests

### DIFF
--- a/chirpy/api.py
+++ b/chirpy/api.py
@@ -195,6 +195,9 @@ class TwitterCall(object):
         elif method == 'POST':
             post_data = json.dumps(json_body) if json_body is not None else kwargs
             request = partial(requests.request, data=post_data)
+        elif method == 'PUT':
+            put_data = json.dumps(json_body) if json_body is not None else kwargs
+            request = partial(requests.request, params=kwargs, data=put_data)
 
         resp = request(method, uriBase, headers=headers, timeout=_timeout,
             proxies=self.proxies, auth=self.auth)


### PR DESCRIPTION
Pretty self-explanatory - currently, PUT requests break because `request` gets referenced before assignment. This adds them to the conditional that builds the partial request, and ensures it includes querystring params and a request body.

@gordonkristan You were the last person to work on any of this stuff, so I'm just tagging you for good measure.